### PR TITLE
ci: add test workflow for JS and Swift tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run JS tests
+        run: npm run test:js
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Run Swift tests
+        run: npm run test:swift

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# mdv
+
+macOS向けMarkdownビューアアプリ。Swift (AppKit) + TypeScript (marked, mermaid, shiki) で構成。
+
+## ビルド・テスト
+
+```bash
+npm ci
+npm run test:js    # JSテスト (vitest)
+npm run test:swift # Swiftテスト (xcodegen + xcodebuild)
+npm run build      # フルビルド
+```
+
+## 開発ルール
+
+- PRを作成してmainにマージすること。mainへの直接pushは避ける。


### PR DESCRIPTION
JS (vitest) と Swift (xcodebuild) のテストを実行するCIワークフローを追加。CLAUDE.mdも追加。