### PR TITLE
chore: add Renovate for weekly grouped dependency updates with automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 9am on monday"],
+  "timezone": "Asia/Tokyo",
+  "automerge": true,
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "groupName": "all-dependencies",
+      "groupSlug": "all-dependencies"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
Renovate GitHub App用の設定ファイルを追加。週次で全依存を1つのPRにグループ化し、platformAutomergeでテスト通過後に自動マージする。

## マージ後の手動設定

1. Settings > General > Pull Requests > "Allow auto-merge" を有効化
2. Settings > Rules > Rulesets で main ブランチに `Test / test` ステータスチェック必須のrulesetを作成
3. https://github.com/apps/renovate からRenovate Appをインストール