### PR TITLE
chore: disable lock file maintenance in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,6 @@
     }
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": false
   }
 }


### PR DESCRIPTION
lock file maintenanceを無効化。直接依存の更新のみRenovateに任せる。