### PR TITLE
chore: pin github actions to sha digests via renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "schedule": [
     "before 9am on monday"


### PR DESCRIPTION
helpers:pinGitHubActionDigestsプリセットを追加。Renovateが次回スキャン時にGitHub ActionsをSHAピン留めするPRを作成する。