### PR TITLE
chore(ci): pin node version to 25.8.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 'latest'
+          node-version: '25.8.1'
 
       - name: Install xcodegen
         run: brew install xcodegen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 'latest'
+          node-version: '25.8.1'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
GitHub Actionsワークフローのnode-versionを`latest`から`25.8.1`にピン留め。Renovateによるバージョン管理に移行する。