### PR TITLE
chore(release): switch distribution format from zip to dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Create release
         run: |
           gh release create ${{ steps.calver.outputs.tag }} \
-            mdv-${{ steps.calver.outputs.version }}-macos.zip \
+            mdv-${{ steps.calver.outputs.version }}-macos.dmg \
             --generate-notes \
             --target ${{ github.sha }}
         env:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,7 +31,9 @@ xcodebuild build \
 
 if [ -n "${VERSION:-}" ]; then
   APP_PATH="build/Build/Products/Release/mdv.app"
-  ZIP_NAME="mdv-${VERSION}-macos.zip"
-  ditto -c -k --keepParent "$APP_PATH" "$ZIP_NAME"
-  echo "Created $ZIP_NAME"
+  DMG_NAME="mdv-${VERSION}-macos.dmg"
+  hdiutil create -volname "mdv" \
+    -srcfolder "$APP_PATH" \
+    -ov -format UDZO "$DMG_NAME"
+  echo "Created $DMG_NAME"
 fi


### PR DESCRIPTION
## Summary
- build.sh: `ditto -c -k` (zip) を `hdiutil create` (dmg) に変更
- release.yml: アーティファクトのファイル名を `.zip` → `.dmg` に変更

dmg 形式にすることで、ダウンロード後の quarantine 属性の扱いが安定し、右クリック → 開く で Gatekeeper を回避しやすくなります。

## Test plan
- [ ] `VERSION=test scripts/build.sh` でdmgが生成されることを確認
- [ ] 生成されたdmgをマウントしてmdv.appが含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)