### PR TITLE
chore(release): use create-dmg for drag-and-drop installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           node-version: '25.8.1'
 
-      - name: Install xcodegen
-        run: brew install xcodegen
+      - name: Install xcodegen and create-dmg
+        run: brew install xcodegen create-dmg
 
       - name: Calculate CalVer tag
         id: calver

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ Useful as a preview tool for coding agents — add `mdv` to your AGENTS.md to le
 
 Download the latest dmg from [Releases](https://github.com/negipo/mdv/releases), open it, and drag `mdv.app` to `/Applications`.
 
-On first launch, macOS may show a warning about an unidentified developer. Right-click the app and select "Open" to bypass the warning.
-
-If that doesn't work, go to System Settings > Privacy & Security, scroll down, and click "Open Anyway" next to the blocked app message. Alternatively, run:
+On first launch, macOS will block the app because it is not signed. Run the following command before launching:
 
 ```bash
 xattr -cr /Applications/mdv.app

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,8 +32,13 @@ xcodebuild build \
 if [ -n "${VERSION:-}" ]; then
   APP_PATH="build/Build/Products/Release/mdv.app"
   DMG_NAME="mdv-${VERSION}-macos.dmg"
-  hdiutil create -volname "mdv" \
-    -srcfolder "$APP_PATH" \
-    -ov -format UDZO "$DMG_NAME"
+  create-dmg \
+    --volname "mdv" \
+    --window-size 600 400 \
+    --icon-size 128 \
+    --icon "mdv.app" 150 200 \
+    --app-drop-link 450 200 \
+    --no-internet-enable \
+    "$DMG_NAME" "$APP_PATH"
   echo "Created $DMG_NAME"
 fi


### PR DESCRIPTION
## Summary
- build.sh: hdiutil → create-dmg に変更（Applications リンク付き、ウィンドウレイアウト設定）
- release.yml: brew install に create-dmg を追加
- README: xattr -cr を第一案内に戻し、右クリック → 開くの案内を削除

## Test plan
- [ ] CI が通ることを確認
- [ ] リリース後、dmg を開いて Applications へのドラッグ&ドロップが可能なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)