### PR TITLE
fix: show CLI install prompt before file open dialog on first launch

### DIFF
--- a/mdv/AppDelegate.swift
+++ b/mdv/AppDelegate.swift
@@ -7,6 +7,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     func applicationDidFinishLaunching(_ notification: Notification) {
         isFinishedLaunching = true
         buildMenu()
+        promptCLIInstallIfNeeded()
 
         if !pendingFilePaths.isEmpty {
             for path in pendingFilePaths {
@@ -34,8 +35,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                 }
             }
         }
-
-        promptCLIInstallIfNeeded()
     }
 
     func application(_ sender: NSApplication, open urls: [URL]) {


### PR DESCRIPTION
## What
初回起動時のダイアログ表示順序を修正

## Why
FileOpenダイアログとCLIインストールプロンプトが同時に表示されていた

## How
`promptCLIInstallIfNeeded()` の呼び出しをファイル処理ロジックの前に移動