### PR TITLE
chore: add 3-day minimum release age to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "before 9am on monday"
   ],
   "timezone": "Asia/Tokyo",
+  "minimumReleaseAge": "3 days",
   "automerge": true,
   "platformAutomerge": true,
   "packageRules": [


### PR DESCRIPTION
Renovateで新しいリリースから3日間のクーリング期間を設定する。