### PR TITLE
fix: correct tab bar height on initial launch with single tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,13 @@ npm run build      # Full build
 
 - Create a PR and merge into main. Avoid pushing directly to main.
 - All user-facing UI text (menu items, labels, alerts, etc.) must be in English.
+
+## Manual UI Verification
+
+When verifying UI changes, kill the running app, rebuild, and relaunch for the user to check:
+
+```bash
+pkill -x mdv 2>/dev/null
+xcodebuild -scheme mdv -configuration Debug build 2>&1 | tail -5
+open ~/Library/Developer/Xcode/DerivedData/mdv-afrghrsxmvulxhcshpjiumlziahy/Build/Products/Debug/mdv.app
+```

--- a/mdv/TitlebarTabsWindow.swift
+++ b/mdv/TitlebarTabsWindow.swift
@@ -114,6 +114,15 @@ class TitlebarTabsWindow: NSWindow {
             accessoryView.topAnchor.constraint(equalTo: accessoryClipView.topAnchor).isActive = true
             accessoryView.heightAnchor.constraint(equalTo: accessoryClipView.heightAnchor).isActive = true
 
+            if let tabBar = accessoryView.firstDescendant(withClassName: "NSTabBar") {
+                let expectedHeight = accessoryClipView.frame.height - 12
+                if tabBar.frame.height > expectedHeight {
+                    var tabFrame = tabBar.frame
+                    tabFrame.size.height = expectedHeight
+                    tabBar.frame = tabFrame
+                }
+            }
+
             accessoryClipView.wantsLayer = true
             accessoryClipView.layer?.sublayerTransform = CATransform3DMakeTranslation(0, -2, 0)
 


### PR DESCRIPTION
Closes #28

What: NSTabBarの初期高さを修正
Why: 起動直後の単一タブ時にタブバーが数ピクセル大きく表示されていた
How: pushTabsToTitlebar内でNSTabBarのフレーム高さを期待値に補正