### PR TITLE
fix: use -a flag in CLI wrapper to open files with mdv

### DIFF
--- a/resources/bin/mdv
+++ b/resources/bin/mdv
@@ -5,5 +5,5 @@ APP_PATH="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 if [ $# -eq 0 ]; then
   open "$APP_PATH"
 else
-  open "$APP_PATH" "$@"
+  open -a "$APP_PATH" "$@"
 fi


### PR DESCRIPTION
open "$APP_PATH" "$@" だと引数がデフォルトアプリで開かれてしまう問題を修正。
open -a "$APP_PATH" "$@" でmdvアプリを明示的に指定。