### PR TITLE
fix: simplify CLI wrapper to use fixed /Applications path

### DIFF
--- a/resources/bin/mdv
+++ b/resources/bin/mdv
@@ -1,6 +1,5 @@
 #!/bin/bash
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-APP_PATH="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+APP_PATH="/Applications/mdv.app"
 
 if [ $# -eq 0 ]; then
   open "$APP_PATH"


### PR DESCRIPTION
シンボリックリンク経由で実行すると相対パス算出が壊れる問題を修正。
/Applications/mdv.app を直接指定するシンプルな方式に変更。