### PR TITLE
feat: redesign help with menu and titlebar icon entry points

### DIFF
--- a/mdv/AppDelegate.swift
+++ b/mdv/AppDelegate.swift
@@ -207,6 +207,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     @objc private func sendToAppAction(_ sender: Any?) {
         withKeyWindowController { $0.sendToApp() }
     }
+
+    @objc private func showKeyboardShortcutsAction(_ sender: Any?) {
+        withKeyWindowController { $0.showShortcutHelp(nil) }
+    }
 }
 
 // MARK: - Menu
@@ -223,8 +227,12 @@ extension AppDelegate {
         let windowMenuItem = buildWindowMenuItem()
         mainMenu.addItem(windowMenuItem)
 
+        let helpMenuItem = buildHelpMenuItem()
+        mainMenu.addItem(helpMenuItem)
+
         NSApplication.shared.mainMenu = mainMenu
         NSApplication.shared.windowsMenu = windowMenuItem.submenu
+        NSApplication.shared.helpMenu = helpMenuItem.submenu
     }
 
     private func buildAppMenuItem() -> NSMenuItem {
@@ -370,6 +378,18 @@ extension AppDelegate {
             keyEquivalent: "f"
         )
         fullScreen.keyEquivalentModifierMask = [.command, .control]
+        item.submenu = menu
+        return item
+    }
+
+    private func buildHelpMenuItem() -> NSMenuItem {
+        let item = NSMenuItem()
+        let menu = NSMenu(title: "Help")
+        menu.addItem(
+            withTitle: "Keyboard Shortcuts",
+            action: #selector(showKeyboardShortcutsAction(_:)),
+            keyEquivalent: ""
+        )
         item.submenu = menu
         return item
     }

--- a/mdv/MarkdownWindowController+ShortcutHelp.swift
+++ b/mdv/MarkdownWindowController+ShortcutHelp.swift
@@ -15,16 +15,23 @@ extension MarkdownWindowController {
         SendTarget.isConfigured ? "Send to \(SendTarget.appName ?? "App")" : "Send to\u{2026}"
     }
 
-    func showShortcutHelp() {
+    @objc func showShortcutHelp(_ sender: Any? = nil) {
         let path = Self.helpFilePath
         try? generateShortcutHelpContent().write(toFile: path, atomically: true, encoding: .utf8)
         WindowManager.shared.openOrFocus(filePath: path)
     }
 
-    private func generateShortcutHelpContent() -> String {
-        """
-# Keyboard Shortcuts
+    func generateShortcutHelpContent() -> String {
+        [
+            "# Keyboard Shortcuts & Mouse Manipulations",
+            Self.singleKeyShortcutsSection,
+            Self.menuShortcutsSection,
+            Self.mouseManipulationsSection
+        ].joined(separator: "\n\n") + "\n"
+    }
 
+    private static var singleKeyShortcutsSection: String {
+        """
 ## Single-Key Shortcuts
 
 | Key | Action |
@@ -44,9 +51,13 @@ extension MarkdownWindowController {
 | `l` | Copy Relative Path with Lines |
 | `y` | Copy Path:Line + Content |
 | `m` | Copy File as Markdown |
-| `s` | \(Self.sendKeyLabel) |
+| `s` | \(sendKeyLabel) |
 | `?` | Show this help |
+"""
+    }
 
+    private static var menuShortcutsSection: String {
+        """
 ## Menu Shortcuts
 
 | Shortcut | Action |
@@ -55,7 +66,7 @@ extension MarkdownWindowController {
 | `Cmd+W` | Close Tab |
 | `Cmd+Shift+T` | Reopen Closed Tab |
 | `Cmd+F` | Find |
-| `Cmd+S` | \(Self.sendMenuLabel) |
+| `Cmd+S` | \(sendMenuLabel) |
 | `Cmd+R` | Reload |
 | `Cmd+T` | Table of Contents |
 | `Cmd++` | Zoom In |
@@ -67,6 +78,21 @@ extension MarkdownWindowController {
 | `Cmd+Shift+Option+C` | Copy Absolute Path |
 | `Cmd+Shift+M` | Copy File as Markdown |
 | `Cmd+Ctrl+F` | Toggle Full Screen |
+"""
+    }
+
+    private static var mouseManipulationsSection: String {
+        """
+## Mouse Manipulations
+
+### Mermaid Diagram Overlay
+
+| Action | Behavior |
+|--------|----------|
+| Click | Open overlay |
+| Scroll | Zoom in/out at cursor |
+| Drag | Pan (move) |
+| `Esc` | Close overlay |
 """
     }
 }

--- a/mdv/TitlebarTabsWindow.swift
+++ b/mdv/TitlebarTabsWindow.swift
@@ -6,6 +6,7 @@ class TitlebarTabsWindow: NSWindow {
     private var windowButtonsBackdrop: WindowButtonsBackdropView?
     private var windowDragHandle: WindowDragView?
     private var tocToggleButton: NSButton?
+    private var helpButton: NSButton?
 
     override init(
         contentRect: NSRect, styleMask style: NSWindow.StyleMask,
@@ -105,6 +106,7 @@ class TitlebarTabsWindow: NSWindow {
             guard let windowButtonsBackdrop = self?.windowButtonsBackdrop else { return }
 
             self?.addTocToggleButton(titlebarView: titlebarView, toolbarView: toolbarView)
+            self?.addHelpButton(titlebarView: titlebarView, toolbarView: toolbarView)
 
             self?.addWindowDragHandle(titlebarView: titlebarView, toolbarView: toolbarView)
 
@@ -115,9 +117,16 @@ class TitlebarTabsWindow: NSWindow {
                 tabLeftAnchor = windowButtonsBackdrop.rightAnchor
             }
 
+            let tabRightAnchor: NSLayoutXAxisAnchor
+            if let helpButton = self?.helpButton, helpButton.superview == titlebarView {
+                tabRightAnchor = helpButton.leftAnchor
+            } else {
+                tabRightAnchor = toolbarView.rightAnchor
+            }
+
             accessoryClipView.translatesAutoresizingMaskIntoConstraints = false
             accessoryClipView.leftAnchor.constraint(equalTo: tabLeftAnchor).isActive = true
-            accessoryClipView.rightAnchor.constraint(equalTo: toolbarView.rightAnchor).isActive = true
+            accessoryClipView.rightAnchor.constraint(equalTo: tabRightAnchor, constant: -4).isActive = true
             accessoryClipView.topAnchor.constraint(equalTo: toolbarView.topAnchor).isActive = true
             accessoryClipView.heightAnchor.constraint(equalTo: toolbarView.heightAnchor).isActive = true
 
@@ -196,6 +205,37 @@ class TitlebarTabsWindow: NSWindow {
         tocToggleButton = button
     }
 
+    private func addHelpButton(titlebarView: NSView, toolbarView: NSView) {
+        guard helpButton?.superview != titlebarView else { return }
+        helpButton?.removeFromSuperview()
+        helpButton = nil
+
+        let button = NSButton(frame: .zero)
+        let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
+        let icon = NSImage(
+            systemSymbolName: "questionmark.circle",
+            accessibilityDescription: "Keyboard Shortcuts & Mouse Manipulations"
+        )?.withSymbolConfiguration(config)
+        button.image = icon
+        button.contentTintColor = .labelColor
+        button.bezelStyle = .toolbar
+        button.setButtonType(.momentaryPushIn)
+        button.isBordered = false
+        button.target = nil
+        button.action = #selector(MarkdownWindowController.showShortcutHelp(_:))
+        button.toolTip = "Keyboard Shortcuts & Mouse Manipulations"
+        button.identifier = NSUserInterfaceItemIdentifier("_helpButton")
+        titlebarView.addSubview(button)
+
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.rightAnchor.constraint(equalTo: toolbarView.rightAnchor, constant: -4).isActive = true
+        button.centerYAnchor.constraint(equalTo: toolbarView.centerYAnchor).isActive = true
+        button.widthAnchor.constraint(equalToConstant: 36).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 28).isActive = true
+
+        helpButton = button
+    }
+
     private func addWindowDragHandle(titlebarView: NSView, toolbarView: NSView) {
         guard windowDragHandle?.superview != titlebarView.superview else { return }
         windowDragHandle?.removeFromSuperview()
@@ -249,6 +289,13 @@ private class WindowDragView: NSView {
         if let tocButton = titlebarView.subviews.first(where: { $0.identifier?.rawValue == "_tocToggleButton" }) {
             let pointInButton = tocButton.convert(point, from: superview)
             if tocButton.bounds.contains(pointInButton) {
+                return nil
+            }
+        }
+
+        if let helpButton = titlebarView.subviews.first(where: { $0.identifier?.rawValue == "_helpButton" }) {
+            let pointInButton = helpButton.convert(point, from: superview)
+            if helpButton.bounds.contains(pointInButton) {
                 return nil
             }
         }

--- a/mdvTests/AppDelegateTests.swift
+++ b/mdvTests/AppDelegateTests.swift
@@ -174,4 +174,33 @@ final class AppDelegateTests: XCTestCase {
         XCTAssertEqual(absPath?.keyEquivalent, "c")
         XCTAssertEqual(absPath?.keyEquivalentModifierMask, [.command, .option, .shift])
     }
+
+    // Helpメニューが存在する
+    func testHelpMenuExists() {
+        let mainMenu = NSApplication.shared.mainMenu
+        let helpMenu = mainMenu?.items.first { $0.submenu?.title == "Help" }?.submenu
+        XCTAssertNotNil(helpMenu, "Help menu should exist")
+    }
+
+    // Helpメニューが NSApplication.helpMenu として登録されている
+    func testHelpMenuIsRegisteredAsHelpMenu() {
+        XCTAssertNotNil(NSApplication.shared.helpMenu, "helpMenu should be registered")
+        XCTAssertEqual(NSApplication.shared.helpMenu?.title, "Help")
+    }
+
+    // HelpメニューにKeyboard Shortcuts項目が含まれている
+    func testHelpMenuContainsShortcutsItem() {
+        let mainMenu = NSApplication.shared.mainMenu
+        let helpMenu = mainMenu?.items.first { $0.submenu?.title == "Help" }?.submenu
+        let shortcutsItem = helpMenu?.items.first { $0.title == "Keyboard Shortcuts" }
+        XCTAssertNotNil(shortcutsItem, "Keyboard Shortcuts menu item should exist in Help menu")
+    }
+
+    // Helpメニューがメニューバーの最後（Window メニューより後）に配置されている
+    func testHelpMenuIsLast() {
+        let mainMenu = NSApplication.shared.mainMenu
+        XCTAssertNotNil(mainMenu)
+        let lastItem = mainMenu!.items.last
+        XCTAssertEqual(lastItem?.submenu?.title, "Help", "Help menu should be the last top-level menu")
+    }
 }

--- a/mdvTests/ShortcutHelpContentTests.swift
+++ b/mdvTests/ShortcutHelpContentTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import mdv
+
+final class ShortcutHelpContentTests: XCTestCase {
+    private var controller: MarkdownWindowController!
+
+    override func setUp() {
+        super.setUp()
+        let state = WindowManager.WindowState()
+        controller = MarkdownWindowController(windowState: state)
+    }
+
+    override func tearDown() {
+        controller.window?.orderOut(nil)
+        controller.window?.close()
+        controller = nil
+        super.tearDown()
+    }
+
+    // ヘルプ本文のタイトルがKeyboard Shortcuts & Mouse Manipulationsになっている
+    func testTitleIncludesMouseManipulations() {
+        let content = controller.generateShortcutHelpContent()
+        XCTAssertTrue(
+            content.contains("# Keyboard Shortcuts & Mouse Manipulations"),
+            "Title should be 'Keyboard Shortcuts & Mouse Manipulations'"
+        )
+    }
+
+    // Mouse Manipulationsセクションが含まれている
+    func testMouseManipulationsSectionExists() {
+        let content = controller.generateShortcutHelpContent()
+        XCTAssertTrue(
+            content.contains("## Mouse Manipulations"),
+            "Mouse Manipulations section should exist"
+        )
+    }
+
+    // Mermaid Overlayのホイール拡大縮小が記載されている
+    func testMermaidWheelZoomDocumented() {
+        let content = controller.generateShortcutHelpContent()
+        XCTAssertTrue(
+            content.contains("Mermaid"),
+            "Mermaid should be mentioned"
+        )
+        XCTAssertTrue(
+            content.contains("Scroll") || content.contains("scroll"),
+            "Scroll (wheel) action should be documented"
+        )
+    }
+
+    // Mermaid Overlayのドラッグ移動が記載されている
+    func testMermaidDragPanDocumented() {
+        let content = controller.generateShortcutHelpContent()
+        XCTAssertTrue(
+            content.contains("Drag") || content.contains("drag"),
+            "Drag action should be documented"
+        )
+    }
+
+    // Escで閉じられることが記載されている
+    func testMermaidEscCloseDocumented() {
+        let content = controller.generateShortcutHelpContent()
+        XCTAssertTrue(
+            content.contains("Esc") || content.contains("Escape"),
+            "Esc key should be documented"
+        )
+    }
+
+    // 既存のSingle-Key Shortcutsセクションは維持されている
+    func testSingleKeyShortcutsSectionStillExists() {
+        let content = controller.generateShortcutHelpContent()
+        XCTAssertTrue(
+            content.contains("## Single-Key Shortcuts"),
+            "Single-Key Shortcuts section should be preserved"
+        )
+    }
+}


### PR DESCRIPTION
closes #81

## What
ヘルプへの導線にmacOS標準のHelpメニューとタイトルバー右端の`?`アイコンを追加し、本文にMermaid overlayのマウス操作を記載する。