### PR TITLE
docs: drop manual xattr step from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Useful as a preview tool for coding agents — add `mdv` to your AGENTS.md to le
 
 ```bash
 brew install --cask negipo/tap/mdv
-xattr -dr com.apple.quarantine /Applications/mdv.app
 ```
 
 Open a Markdown file from the terminal:


### PR DESCRIPTION
## Summary

cask 側 (https://github.com/negipo/homebrew-tap/pull/2) で postflight が `xattr -dr com.apple.quarantine` を自動実行するようになるため、README の Installation セクションから手動 `xattr` 行を削除する。

## Dependency

https://github.com/negipo/homebrew-tap/pull/2 が先にマージされる想定。README が先にマージされてもアプリ側の機能は壊れないが、cask 側マージ前のユーザには一時的に手順不足に見える点に注意。

## Test plan

- [x] `mdv README.md` でプレビューを開き、Installation セクションが `brew install --cask negipo/tap/mdv` 1 行だけの code block になっていることを確認