### PR TITLE
feat: open panel starts in focused tab's directory

### DIFF
--- a/mdv/WindowManager.swift
+++ b/mdv/WindowManager.swift
@@ -89,6 +89,11 @@ class WindowManager {
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
 
+        if let controller = NSApplication.shared.keyWindow?.windowController as? MarkdownWindowController,
+           let path = controller.filePath {
+            panel.directoryURL = URL(fileURLWithPath: (path as NSString).deletingLastPathComponent)
+        }
+
         NSApplication.shared.activate(ignoringOtherApps: true)
         if panel.runModal() == .OK {
             for url in panel.urls {


### PR DESCRIPTION
## Summary
- `Cmd+O` (File > Open…) now opens the file picker rooted at the directory of the file in the focused tab.
- When no markdown tab is focused (e.g. settings window or no windows), behaviour is unchanged — AppKit's default location is used.

## Test plan
- [x] `npm run test:swift`
- [x] `npm run test:js`
- [ ] Manual: focus a markdown tab, press `Cmd+O`, confirm the open panel starts in that file's directory.
- [ ] Manual: with only the settings window open (or no windows), press `Cmd+O` from menu, confirm AppKit default location is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)