### PR TITLE
chore(skills): use merge commit for release and add install-mdv

### DIFF
--- a/.claude/skills/installing-mdv/SKILL.md
+++ b/.claude/skills/installing-mdv/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: installing-mdv
+description: Install or reinstall the latest mdv from negipo/tap. Use when the user asks to install, reinstall, or update mdv (typically right after a release).
+---
+
+Always use the cask from `negipo/tap`. The plain `mdv` formula in homebrew/core is a different (Python) tool and must not be installed here.
+
+```bash
+brew update
+brew reinstall --cask negipo/tap/mdv
+```
+
+If `brew reinstall` fails because mdv is not installed, fall back to:
+
+```bash
+brew install --cask negipo/tap/mdv
+```
+
+After installation, report the installed version:
+
+```bash
+brew list --cask --versions mdv | \cat
+```

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -14,11 +14,11 @@ Create a pull request. Skip this step if one already exists for the current bran
 
 ### 2. Enable automerge
 
-Mark the PR as ready if it is a draft, then enable automerge with squash.
+Mark the PR as ready if it is a draft, then enable automerge with a merge commit.
 
 ```bash
 gh pr ready
-gh pr merge --auto --squash
+gh pr merge --auto --merge
 ```
 
 ### 3. Wait for merge


### PR DESCRIPTION
## What
- `releasing` skill の automerge を `--squash` から `--merge` に変更
- `installing-mdv` skill を新規追加